### PR TITLE
Fix Typos

### DIFF
--- a/src/main/java/se/solrike/sonarlint/Sonarlint.java
+++ b/src/main/java/se/solrike/sonarlint/Sonarlint.java
@@ -152,7 +152,7 @@ public abstract class Sonarlint extends SourceTask {
     SonarlintAction action = new SonarlintAction();
     List<IssueEx> issues = action.run(this);
 
-    String resultMessage = String.format("%d SonarLint issue(s) where found. Max issue(s) allowed: %d.", issues.size(),
+    String resultMessage = String.format("%d SonarLint issue(s) were found. Max issue(s) allowed: %d.", issues.size(),
         getMaxIssues().getOrElse(0));
     logger.error(resultMessage);
 

--- a/src/test/java/se/solrike/sonarlint/IntegrationTest.java
+++ b/src/test/java/se/solrike/sonarlint/IntegrationTest.java
@@ -62,7 +62,7 @@ class IntegrationTest {
     // then the gradle build shall fail
     assertThat(buildResult.task(":sonarlintMain").getOutcome()).isEqualTo(TaskOutcome.FAILED);
     // and the 3 sonarlint rules violated are
-    assertThat(buildResult.getOutput()).contains("3 SonarLint issue(s) where found.");
+    assertThat(buildResult.getOutput()).contains("3 SonarLint issue(s) were found.");
     assertThat(buildResult.getOutput()).contains("java:S1186", "java:S1118", "java:S1220");
 
     System.err.println(buildResult.getOutput());


### PR DESCRIPTION
quick fix for `where` vs `were` in two places. As this is user facing output it looks bad when using this awesome plugin.