### PR TITLE
Exclude Java Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ sonarlint {
       'exclusion': '**.private.**'] // do not need javadoc for classes under 'private'. Default is **.internal.**
   ]
   showIssues = true // default true
+  excludePackages = ['com.company.some.generated.package']
 }
 ```
 

--- a/src/main/java/se/solrike/sonarlint/Sonarlint.java
+++ b/src/main/java/se/solrike/sonarlint/Sonarlint.java
@@ -63,6 +63,15 @@ public abstract class Sonarlint extends SourceTask {
   @Optional
   public abstract Property<Boolean> getIgnoreFailures();
 
+  /**
+   * List of java packages to be excluded from the analysis. E.g '["com.company.generated"]'.
+   *
+   * @return list if excluded packages
+   */
+  @Input
+  @Optional
+  public abstract SetProperty<String> getExcludePackages();
+
   @Input
   @Optional
   public abstract Property<Boolean> getIsTestSource();

--- a/src/main/java/se/solrike/sonarlint/SonarlintExtension.java
+++ b/src/main/java/se/solrike/sonarlint/SonarlintExtension.java
@@ -7,7 +7,9 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
 
 /**
  * @author Lucas Persson
@@ -34,6 +36,15 @@ public interface SonarlintExtension {
    * @return true if failures should be ignored
    */
   Property<Boolean> getIgnoreFailures();
+
+  /**
+   * List of java packages to be excluded from the analysis. E.g '["com.company.generated"]'.
+   *
+   * @return list if excluded packages
+   */
+  @Input
+  @Optional
+  SetProperty<String> getExcludePackages();
 
   /**
    * The maximum number of issues that are tolerated before breaking the build. Defaults to <code>0</code>.

--- a/src/main/java/se/solrike/sonarlint/SonarlintPlugin.java
+++ b/src/main/java/se/solrike/sonarlint/SonarlintPlugin.java
@@ -124,6 +124,7 @@ public class SonarlintPlugin implements Plugin<Project> {
       task.getShowIssues().set(extension.getShowIssues());
       task.getReportsDir().set(extension.getReportsDir());
       task.getReports().addAll(extension.getReports().getAsMap().values());
+      task.getExcludePackages().addAll(extension.getExcludePackages());
 
     });
 

--- a/src/main/java/se/solrike/sonarlint/exclusions/ExcludeByPackage.java
+++ b/src/main/java/se/solrike/sonarlint/exclusions/ExcludeByPackage.java
@@ -1,0 +1,35 @@
+package se.solrike.sonarlint.exclusions;
+
+import java.io.File;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class ExcludeByPackage implements Predicate<File> {
+
+    private final Set<String> packages;
+    private final Function<File, Optional<String>> getPackage;
+
+
+    public ExcludeByPackage(Set<String> packages) {
+        this(packages, PackageOfJavaFile::get);
+    }
+
+    public ExcludeByPackage(Set<String> packages, Function<File, Optional<String>> getPackage) {
+        this.packages = packages;
+        this.getPackage = getPackage;
+    }
+
+    @Override
+    public boolean test(File file) {
+        return packages.stream().noneMatch(p -> packageOfFileStartsWith(p, file));
+    }
+
+    private boolean packageOfFileStartsWith(String excludePackage, File file) {
+        return getPackage.apply(file)
+                .map(s -> s.startsWith(excludePackage))
+                .orElse(false);
+    }
+
+}

--- a/src/main/java/se/solrike/sonarlint/exclusions/ExcludeByPackage.java
+++ b/src/main/java/se/solrike/sonarlint/exclusions/ExcludeByPackage.java
@@ -23,12 +23,12 @@ public class ExcludeByPackage implements Predicate<File> {
 
     @Override
     public boolean test(File file) {
-        return packages.stream().noneMatch(p -> packageOfFileStartsWith(p, file));
+        return packages.stream().noneMatch(p -> packageOfFileEquals(p, file));
     }
 
-    private boolean packageOfFileStartsWith(String excludePackage, File file) {
+    private boolean packageOfFileEquals(String excludePackage, File file) {
         return getPackage.apply(file)
-                .map(s -> s.startsWith(excludePackage))
+                .map(excludePackage::equals)
                 .orElse(false);
     }
 

--- a/src/main/java/se/solrike/sonarlint/exclusions/PackageOfJavaFile.java
+++ b/src/main/java/se/solrike/sonarlint/exclusions/PackageOfJavaFile.java
@@ -1,0 +1,45 @@
+package se.solrike.sonarlint.exclusions;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class PackageOfJavaFile {
+
+    private static final Pattern PACKAGE_REGEX = Pattern.compile("^package (.+?);$");
+    public static Optional<String> get(File file) {
+        if(!file.getName().endsWith(".java")){
+            return Optional.empty();
+        }
+        try {
+            return parsePackage(file);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Optional<String> parsePackage(File file) throws IOException {
+        try(Stream<String> lines = Files.lines(file.toPath())){
+            return lines
+                    .filter(PackageOfJavaFile::isPackageDeclarationLine)
+                    .findFirst()
+                    .map(PackageOfJavaFile::extractPackage);
+        }
+    }
+
+    private static boolean isPackageDeclarationLine(String line) {
+        return line.startsWith("package ");
+    }
+
+    private static String extractPackage(String line) {
+        Matcher matcher = PACKAGE_REGEX.matcher(line);
+        if(matcher.matches()){
+            return matcher.group(1);
+        }
+        throw new IllegalArgumentException(String.format("could not read package from line: %s", line));
+    }
+}

--- a/src/main/java/se/solrike/sonarlint/exclusions/PackageOfJavaFile.java
+++ b/src/main/java/se/solrike/sonarlint/exclusions/PackageOfJavaFile.java
@@ -11,6 +11,11 @@ import java.util.stream.Stream;
 public class PackageOfJavaFile {
 
     private static final Pattern PACKAGE_REGEX = Pattern.compile("^package (.+?);$");
+
+    private PackageOfJavaFile(){
+        // static use only
+    }
+
     public static Optional<String> get(File file) {
         if(!file.getName().endsWith(".java")){
             return Optional.empty();

--- a/src/test/java/se/solrike/sonarlint/exclusions/ExcludeByPackageTest.java
+++ b/src/test/java/se/solrike/sonarlint/exclusions/ExcludeByPackageTest.java
@@ -28,7 +28,7 @@ class ExcludeByPackageTest {
         ExcludeByPackage excludeGenerated = new ExcludeByPackage(setOf("com.company.generated"), getPackageMock);
         assertThat(excludeGenerated.test(NORMALFILE)).isTrue();
         assertThat(excludeGenerated.test(GENERATED_FILE)).isFalse();
-        assertThat(excludeGenerated.test(GENERATED_FILE_SUB_PACKAGE)).isFalse();
+        assertThat(excludeGenerated.test(GENERATED_FILE_SUB_PACKAGE)).isTrue();
     }
 
     @Test

--- a/src/test/java/se/solrike/sonarlint/exclusions/ExcludeByPackageTest.java
+++ b/src/test/java/se/solrike/sonarlint/exclusions/ExcludeByPackageTest.java
@@ -1,0 +1,47 @@
+package se.solrike.sonarlint.exclusions;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.*;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.*;
+class ExcludeByPackageTest {
+
+    private static final Map<File, String> testFiles = new HashMap<>();
+    private static final Function<File, Optional<String>> getPackageMock = file ->
+            Optional.ofNullable(testFiles.get(file));
+
+    private static final File NORMALFILE = new File("somefile.java");
+    private static final File GENERATED_FILE = new File("somefilegenerated.java");
+    private static final File GENERATED_FILE_SUB_PACKAGE = new File("somefilegeneratedinpackage.java");
+
+    static {
+        testFiles.put(NORMALFILE, "com.company.production.something");
+        testFiles.put(GENERATED_FILE, "com.company.generated");
+        testFiles.put(GENERATED_FILE_SUB_PACKAGE, "com.company.generated.nested");
+    }
+
+    @Test
+    void generatedShouldBeExcluded() {
+        ExcludeByPackage excludeGenerated = new ExcludeByPackage(setOf("com.company.generated"), getPackageMock);
+        assertThat(excludeGenerated.test(NORMALFILE)).isTrue();
+        assertThat(excludeGenerated.test(GENERATED_FILE)).isFalse();
+        assertThat(excludeGenerated.test(GENERATED_FILE_SUB_PACKAGE)).isFalse();
+    }
+
+    @Test
+    void generatedShouldNotBeExcluded() {
+        ExcludeByPackage excludeGenerated = new ExcludeByPackage(setOf(), getPackageMock);
+        assertThat(excludeGenerated.test(NORMALFILE)).isTrue();
+        assertThat(excludeGenerated.test(GENERATED_FILE)).isTrue();
+        assertThat(excludeGenerated.test(GENERATED_FILE_SUB_PACKAGE)).isTrue();
+    }
+
+    private static Set<String> setOf(String... packages) {
+        Set<String> setOfPackages = new HashSet<>();
+        Collections.addAll(setOfPackages, packages);
+        return setOfPackages;
+    }
+}

--- a/src/test/java/se/solrike/sonarlint/exclusions/PackageOfJavaFileTest.java
+++ b/src/test/java/se/solrike/sonarlint/exclusions/PackageOfJavaFileTest.java
@@ -1,0 +1,29 @@
+package se.solrike.sonarlint.exclusions;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import static org.assertj.core.api.Assertions.*;
+
+class PackageOfJavaFileTest {
+
+    private final String exampleFileDirectory = "src/test/resources/examplejavafiles";
+    private final File textFile = new File(exampleFileDirectory, "text.txt");
+    private final File generatedFile = new File(exampleFileDirectory, "Generated.java");
+    private final File noPackage = new File(exampleFileDirectory, "NoPackage.java");
+
+    @Test
+    void emptyWhenNotJava() {
+        assertThat(PackageOfJavaFile.get(textFile)).isEmpty();
+    }
+
+    @Test
+    void emptyWhenNoPackageFound() {
+        assertThat(PackageOfJavaFile.get(noPackage)).isEmpty();
+    }
+    
+    @Test
+    void getPackageOfJavaFile() {
+        assertThat(PackageOfJavaFile.get(generatedFile)).isNotEmpty().hasValue("com.company.generated");
+    }
+}

--- a/src/test/java/se/solrike/sonarlint/exclusions/text.txt
+++ b/src/test/java/se/solrike/sonarlint/exclusions/text.txt
@@ -1,0 +1,1 @@
+package com.company.generated;

--- a/src/test/resources/examplejavafiles/Generated.java
+++ b/src/test/resources/examplejavafiles/Generated.java
@@ -1,0 +1,3 @@
+package com.company.generated;
+
+class GeneratedClass {}

--- a/src/test/resources/examplejavafiles/NoPackage.java
+++ b/src/test/resources/examplejavafiles/NoPackage.java
@@ -1,0 +1,1 @@
+class NormalClass {}


### PR DESCRIPTION
We started integrating this into our gradle build. And we need this feature to exclude some java files by package.

Our code contains generated classes (e.g. jaxb xml classes and also a generated snmp agent). We want to exclude those classes explicitly by gradle task configuration.

This PR adds this new feature / config:

```groovy
sonarlint {
 ...
  excludePackages = ['com.company.some.generated.package']
}
```

Could you please review and see if this is OK?

Axel