### PR TITLE
Support configuration cache in sonarlint task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import se.solrike.sonarlint.SonarlintListRules
+
 plugins {
   id 'eclipse'
   id 'groovy'
@@ -14,7 +16,7 @@ repositories {
 // latest core ? 8.11.0.56591
 dependencies {
   implementation('io.github.furstenheim:copy_down:1.1')
-  implementation('org.apache.commons:commons-text:1.9')
+  implementation('org.apache.commons:commons-text:1.10.0')
   implementation('org.sonarsource.sonarlint.core:sonarlint-core:8.0.2.42487')
 
   sonarlintPlugins 'org.sonarsource.java:sonar-java-plugin:7.17.0.31219'
@@ -32,7 +34,7 @@ version = '1.0.0-beta.16'
 sourceCompatibility = '11'
 targetCompatibility = '11'
 
-tasks.withType(GroovyCompile) {
+tasks.withType(GroovyCompile).configureEach {
   configure(options) {
     options.compilerArgs << '-Xlint:deprecation' << '-Xlint:unchecked'
   }
@@ -166,7 +168,7 @@ wrapper {
 }
 
 
-task sonarlintListRules(type: se.solrike.sonarlint.SonarlintListRules) {
+tasks.register('sonarlintListRules', SonarlintListRules) {
   description = 'List sonarlint rules'
   group = 'verification'
 }

--- a/src/main/java/se/solrike/sonarlint/SonarlintListRules.java
+++ b/src/main/java/se/solrike/sonarlint/SonarlintListRules.java
@@ -3,7 +3,6 @@ package se.solrike.sonarlint;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -77,7 +76,7 @@ public class SonarlintListRules extends DefaultTask {
     StandaloneSonarLintEngine engine = new StandaloneSonarLintEngineImpl(globalConfiguration);
     try {
       List<StandaloneRuleDetails> rules = new ArrayList<>(engine.getAllRuleDetails());
-      Collections.sort(rules, this::compare);
+      rules.sort(this::compare);
       rules.forEach(this::printRule);
     }
     finally {

--- a/src/main/java/se/solrike/sonarlint/impl/GradleClientLogOutput.java
+++ b/src/main/java/se/solrike/sonarlint/impl/GradleClientLogOutput.java
@@ -14,7 +14,7 @@ import org.sonarsource.sonarlint.core.commons.log.ClientLogOutput;
  */
 public class GradleClientLogOutput implements ClientLogOutput {
 
-  private Logger mLogger;
+  private final Logger mLogger;
 
   private static final Map<Level, LogLevel> sLevelMap = ofEntries(entry(Level.ERROR, LogLevel.ERROR),
       entry(Level.WARN, LogLevel.WARN), entry(Level.INFO, LogLevel.INFO), entry(Level.DEBUG, LogLevel.DEBUG),
@@ -34,6 +34,7 @@ public class GradleClientLogOutput implements ClientLogOutput {
   private boolean supress(String formattedMessage) {
     return formattedMessage.startsWith("No workDir in SonarLint")
         || formattedMessage.startsWith("Analysis engine interrupted")
+        || formattedMessage.startsWith("com.google.gson.JsonIOException")
         || formattedMessage.startsWith("java.lang.InterruptedException");
   }
 


### PR DESCRIPTION
Hi @Lucas3oo,

we are using your sonarlint-gradle-plugin as part of our internal gradle infrastructure.  Since we are supporting the gradle configuration cache in our builds (cf. https://docs.gradle.org/current/userguide/configuration_cache.html), I created an internal patch for your sonarlint-gradle-plugin. This PR just replays this internal patch to your repo, so that we don't have to maintain a separate version of your plugin.

Thanks a lot for providing and maintaining this plugin!

Best regards,
Lukas