### PR TITLE
feat: add minSeverity option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ sonarlint {
   includeRules = ['java:S1176', 'java:S1696', 'java:S4266']
   ignoreFailures = false
   maxIssues = 0 // default 0
+  minSeverity = 0 // default 0
   reportsDir = 'someFolder' // default build/reports/sonarlint
   // note that rule parameter names are case sensitive
   ruleParameters = [

--- a/src/main/java/se/solrike/sonarlint/Sonarlint.java
+++ b/src/main/java/se/solrike/sonarlint/Sonarlint.java
@@ -86,6 +86,16 @@ public abstract class Sonarlint extends SourceTask {
   public abstract Property<Integer> getMaxIssues();
 
   /**
+   * The minimum issues severity that are tolerated before breaking the build or setting the failure property.
+   * Issues severity is defined at org.sonarsource.sonarlint.core.commons.IssueSeverity.
+   *
+   * @return the minimum issue severity allowed
+   */
+  @Input
+  @Optional
+  public abstract Property<Integer> getMinSeverity();
+
+  /**
    * Whether issues are to be displayed on the console. Defaults to <code>true</code>.
    *
    * @return true if issues shall be displayed
@@ -183,17 +193,22 @@ public abstract class Sonarlint extends SourceTask {
     logTaskParameters();
 
     List<IssueEx> issues = mAction.run(this, getSonarlintConfiguration(), getProjectLayout());
+    List<IssueEx> filteredIssues = issues;
+    if (getMinSeverity().get() > 0) {
+      filteredIssues = issues.stream()
+              .filter(issue -> issue.getSeverity().ordinal() > getMinSeverity().get()).collect(Collectors.toList());
+    }
 
-    String resultMessage = String.format("%d SonarLint issue(s) were found. Max issue(s) allowed: %d.", issues.size(),
+    String resultMessage = String.format("%d SonarLint issue(s) were found. Max issue(s) allowed: %d.", filteredIssues.size(),
         getMaxIssues().getOrElse(0));
     logger.error(resultMessage);
 
     ReportAction reportAction = new ReportAction(this, logger, getProjectLayout(), getProjectProvider());
-    reportAction.report(issues);
+    reportAction.report(filteredIssues);
 
     // optionally generate console info
     if (Boolean.TRUE.equals(getShowIssues().getOrElse(Boolean.TRUE)) && logger.isErrorEnabled()) {
-      for (IssueEx issue : issues) {
+      for (IssueEx issue : filteredIssues) {
         logger.error("\n{} {} {} {} at: {}:{}:{}", reportAction.getIssueTypeIcon(issue.getType()),
             reportAction.getIssueSeverityIcon(issue.getSeverity()), issue.getRuleKey(), issue.getMessage(),
             issue.getInputFileRelativePath(), issue.getStartLine(), issue.getStartLineOffset());
@@ -201,7 +216,7 @@ public abstract class Sonarlint extends SourceTask {
     }
 
     boolean ignoreFailures = getIgnoreFailures().getOrElse(Boolean.FALSE);
-    if ((!ignoreFailures) && issues.size() > getMaxIssues().getOrElse(0)) {
+    if ((!ignoreFailures) && filteredIssues.size() > getMaxIssues().getOrElse(0)) {
       // fail build
       throw new GradleException(resultMessage);
     }

--- a/src/main/java/se/solrike/sonarlint/SonarlintExtension.java
+++ b/src/main/java/se/solrike/sonarlint/SonarlintExtension.java
@@ -43,6 +43,14 @@ public interface SonarlintExtension {
   Property<Integer> getMaxIssues();
 
   /**
+   * The minimum issues severity that are tolerated before breaking the build or setting the failure property.
+   * Issues severity is defined at org.sonarsource.sonarlint.core.commons.IssueSeverity.
+   *
+   * @return the minimum issue severity allowed
+   */
+  Property<Integer> getMinSeverity();
+
+  /**
    * The default directory where reports will be generated.
    *
    * @return reports main directory

--- a/src/main/java/se/solrike/sonarlint/SonarlintPlugin.java
+++ b/src/main/java/se/solrike/sonarlint/SonarlintPlugin.java
@@ -65,6 +65,7 @@ public class SonarlintPlugin implements Plugin<Project> {
 
     extension.getIgnoreFailures().set(Boolean.FALSE);
     extension.getMaxIssues().set(0);
+    extension.getMinSeverity().set(0);
     extension.getShowIssues().set(Boolean.TRUE);
 
     DirectoryProperty sonarlintReportsDirectory = project.getObjects()
@@ -119,6 +120,7 @@ public class SonarlintPlugin implements Plugin<Project> {
       task.getExcludeRules().set(extension.getExcludeRules());
       task.getIncludeRules().set(extension.getIncludeRules());
       task.getMaxIssues().set(extension.getMaxIssues());
+      task.getMinSeverity().set(extension.getMinSeverity());
       task.getIgnoreFailures().set(extension.getIgnoreFailures());
       task.getRuleParameters().set(extension.getRuleParameters());
       task.getShowIssues().set(extension.getShowIssues());

--- a/src/main/java/se/solrike/sonarlint/impl/ReportAction.java
+++ b/src/main/java/se/solrike/sonarlint/impl/ReportAction.java
@@ -170,7 +170,7 @@ public class ReportAction {
   private static final Map<IssueSeverity, String> sIssueSeverityIcon = ofEntries(
       entry(IssueSeverity.BLOCKER,  "\uD83C\uDF2A  Block"), // Cloud With Tornado
       entry(IssueSeverity.CRITICAL, "\uD83C\uDF29  Crit."), // Cloud With Lightning
-      entry(IssueSeverity.MAJOR,    "\uD83C\uDF28  Major️"), // Cloud With Snow
+      entry(IssueSeverity.MAJOR,    "\uD83C\uDF28  Major"), // Cloud With Snow
       entry(IssueSeverity.MINOR,    "\uD83C\uDF26  Minor"), // White Sun Behind Cloud With Rain
       entry(IssueSeverity.INFO,     "\uD83C\uDF24  Info ")  // White Sun With Small Cloud
       );

--- a/src/test/java/se/solrike/sonarlint/IntegrationTest.java
+++ b/src/test/java/se/solrike/sonarlint/IntegrationTest.java
@@ -62,6 +62,7 @@ class IntegrationTest {
           + "  reports {"
           + "    sarif.enabled = true\n"
           + "  }\n"
+          + "  minSeverity = 2\n"
           + "}\n"
           + "java {\n"
           + "   sourceCompatibility = '1.8'\n"
@@ -88,8 +89,8 @@ class IntegrationTest {
 
     // then the gradle build shall fail
     assertThat(buildResult.task(":sonarlintMain").getOutcome()).isEqualTo(TaskOutcome.FAILED);
-    // and the 3 sonarlint rules violated are
-    assertThat(buildResult.getOutput()).contains("3 SonarLint issue(s) were found.");
+    // and the 1 sonarlint rules violated, filtered by min severity are
+    assertThat(buildResult.getOutput()).contains("1 SonarLint issue(s) were found.");
     assertThat(buildResult.getOutput()).contains("java:S1186", "java:S1118", "java:S1220");
     // since xml report is enabled the plugin shall print the location of the report
     assertThat(buildResult.getOutput()).contains("Report generated at:");


### PR DESCRIPTION
adding _minSeverity_ option:

> The minimum issues severity that are tolerated before breaking the build or setting the failure property.
Issues severity is defined at org.sonarsource.sonarlint.core.commons.IssueSeverity.

As referred at [issue](https://github.com/Lucas3oo/sonarlint-gradle-plugin/issues/7#issuecomment-2289470707).